### PR TITLE
Adding support for multiple turtlebots

### DIFF
--- a/include/rosplan_interface_turtlebot/RPDocker.h
+++ b/include/rosplan_interface_turtlebot/RPDocker.h
@@ -30,11 +30,12 @@ namespace KCL_rosplan {
 		ros::Publisher action_feedback_pub;
 		ros::Publisher cmd_vel_pub;
 		actionlib::SimpleActionClient<kobuki_msgs::AutoDockingAction> action_client;
+		std::string name;
 
 	public:
 
 		/* constructor */
-		RPDocker(ros::NodeHandle &nh);
+		RPDocker(ros::NodeHandle &nh, std::string turtlebot_name);
 
 		/* listen to and process action_dispatch topic */
 		void dispatchCallback(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg);

--- a/include/rosplan_interface_turtlebot/RPLocaliser.h
+++ b/include/rosplan_interface_turtlebot/RPLocaliser.h
@@ -27,7 +27,7 @@ namespace KCL_rosplan {
 
 	private:
 
-  		tf::TransformListener tfl_;
+		tf::TransformListener tfl_;
 		ros::ServiceClient update_knowledge_client;
 		ros::ServiceClient clear_costmaps_client;
 		ros::Publisher action_feedback_pub;
@@ -35,13 +35,15 @@ namespace KCL_rosplan {
 		ros::Publisher talker_pub;
 
 		std::map<std::string, geometry_msgs::PoseStamped> waypoints;
+		std::string name;
+		std::string prefix;
 
 		void parsePose(geometry_msgs::PoseStamped &pose, std::string line);
 
 	public:
 
 		/* constructor */
-		RPLocaliser(ros::NodeHandle &nh);
+		RPLocaliser(ros::NodeHandle &nh, std::string turtlebot_name, std::string tf_prefix);
 		bool setupRoadmap(std::string filename);
 
 		/* listen to and process action_dispatch topic */


### PR DESCRIPTION
Hi,

In order to use two turtlebot at the same time I had to modify some some interfaces:
- check the name of the robot
- change the name of the robot in the action parameters
- use tf::lookup to be able to use tf_prefix.

This does not change anything in the single-turtlebot case as the name remains kenny by default, and can be change with the `turtlebot_name` parameter.

In case of two turtlebot scenario, all node of the turtlebot and the rosplan_interface should be launched inside a speific namespace. Some topic should be remapped to take into account the namespace:
- /move_base/clear_costmaps -> /turtleX/move_base/clear_costmaps
- /cmd_vel_mux/input/navi ->  /turtleX/cmd_vel_mux/input/navi 
- /dock_drive_action ->  /turtleX/dock_drive_action
- /mobile_base/commands/velocity   ->  /turtleX/mobile_base/commands/velocity

I can also share my launch file if you'd like so.

If this pull request is good for you, I will also put one for the movebase interface in the rosplan repository
